### PR TITLE
Marvelous Battle Update (v3.0)

### DIFF
--- a/assets/cards.json
+++ b/assets/cards.json
@@ -27,7 +27,7 @@
     {
       "id": "atk_card3",
       "name": "Volatile Token",
-      "description": "Deal 10 damage to all enemies and apply 10 bug overtime",
+      "description": "Deal 10 damage to all enemies and apply 10 burn stacks",
       "type": "ATTACK",
       "targetType": "ALL_ENEMIES",
       "cost": 4,
@@ -54,7 +54,7 @@
       "type": "DEFENSE",
       "targetType": "SELF",
       "cost": 2,
-      "baseEffect": 4,
+      "baseEffect": 5,
       "codeEffect": "",
       "suggestion": "",
       "tags": ["DEFENSE", "APPLY_STATUS"]

--- a/core/src/main/java/com/altf4studios/corebringer/entities/Enemy.java
+++ b/core/src/main/java/com/altf4studios/corebringer/entities/Enemy.java
@@ -39,6 +39,13 @@ public class Enemy extends Entity {
         // Implement skill logic here
     }
 
+    // Defensive action: enemy gains shield (block) and skips attack
+    public void defend() {
+        if (!this.isAlive()) return;
+        int blockAmount = Math.max(3, (int)Math.round(this.getDefense() * 1.5));
+        this.gainBlock(blockAmount);
+    }
+
     // Simple attack method for basic turn-based combat
     public void attack(Entity target) {
         if (target != null && target.isAlive() && this.isAlive()) {

--- a/core/src/main/java/com/altf4studios/corebringer/entities/Entity.java
+++ b/core/src/main/java/com/altf4studios/corebringer/entities/Entity.java
@@ -82,8 +82,15 @@ public abstract class Entity implements BattleEntity {
     // Poison management
     public void addPoison(Poison poison) {
         if (poison != null) {
-            poisonEffects.add(poison);
-            poison.onApply();
+            // Merge into a single poison stack so total stacks decrease by 1 per turn
+            if (poisonEffects.isEmpty()) {
+                poisonEffects.add(poison);
+                poison.onApply();
+            } else {
+                Poison existing = poisonEffects.get(0);
+                existing.increasePower(poison.getPower());
+                existing.onApply();
+            }
         }
     }
 

--- a/core/src/main/java/com/altf4studios/corebringer/screens/GameScreen.java
+++ b/core/src/main/java/com/altf4studios/corebringer/screens/GameScreen.java
@@ -175,8 +175,11 @@ public class GameScreen implements Screen{
         }
         // --- End TurnManager Integration ---
 
-        /// For wiring the HP values properly
+        /// For wiring the HP/Shield values properly
         battleStageUI.updateHpBars(player.getHp(), enemy.getHp());
+        battleStageUI.updateShieldBars(player.getBlock(), enemy.getBlock());
+        battleStageUI.updateHpColors(player.hasPoison(), enemy.hasPoison());
+        battleStageUI.updateShieldColors(player.getBlock() > 0, enemy.getBlock() > 0);
 
         // Update turn indicator
         if (turnManager.isPlayerTurn()) {

--- a/core/src/main/java/com/altf4studios/corebringer/screens/gamescreen/BattleStageUI.java
+++ b/core/src/main/java/com/altf4studios/corebringer/screens/gamescreen/BattleStageUI.java
@@ -1,6 +1,7 @@
 package com.altf4studios.corebringer.screens.gamescreen;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -21,6 +22,8 @@ public class BattleStageUI {
     private Stack enemyTemplateStack;
     private Label userHpLabel;
     private Label enemyHpLabel;
+    private Label userShieldLabel;
+    private Label enemyShieldLabel;
     private Label turnIndicatorLabel;
 
     public BattleStageUI(Stage battleStage, Skin skin) {
@@ -92,6 +95,11 @@ public class BattleStageUI {
         // HP Labels
         userHpLabel = new Label("100", skin);
         enemyHpLabel = new Label("100", skin);
+        // Shield Labels (blue)
+        userShieldLabel = new Label("0", skin);
+        userShieldLabel.setColor(Color.CYAN);
+        enemyShieldLabel = new Label("0", skin);
+        enemyShieldLabel.setColor(Color.CYAN);
         Label userTemplate = new Label("", skin);
         Label enemyTemplate = new Label("", skin);
 
@@ -102,11 +110,19 @@ public class BattleStageUI {
         // HP Stacks
         Stack userHpStack = new Stack();
         userHpLabel.setAlignment(Align.center);
-        userHpStack.add(userHpLabel);
+        userShieldLabel.setAlignment(Align.center);
+        Table userHpTable = new Table();
+        userHpTable.add(userHpLabel).row();
+        userHpTable.add(userShieldLabel);
+        userHpStack.add(userHpTable);
 
         Stack enemyHpStack = new Stack();
         enemyHpLabel.setAlignment(Align.center);
-        enemyHpStack.add(enemyHpLabel);
+        enemyShieldLabel.setAlignment(Align.center);
+        Table enemyHpTable = new Table();
+        enemyHpTable.add(enemyHpLabel).row();
+        enemyHpTable.add(enemyShieldLabel);
+        enemyHpStack.add(enemyHpTable);
 
         userTemplate.setAlignment(Align.center);
         enemyTemplate.setAlignment(Align.center);
@@ -128,8 +144,8 @@ public class BattleStageUI {
         enemyTemplateStack.add(enemyTemplate);
 
         actionTable.defaults().padTop(50);
-        actionTable.add(userHpStack).height(25).width(200).padLeft(50);
-        actionTable.add(enemyHpStack).height(25).width(200).padRight(50).row();
+        actionTable.add(userHpStack).height(50).width(200).padLeft(50);
+        actionTable.add(enemyHpStack).height(50).width(200).padRight(50).row();
 
         // Add turn indicator
         actionTable.add(turnIndicatorLabel).colspan(2).height(30).padTop(20).row();
@@ -151,9 +167,36 @@ public class BattleStageUI {
         }
     }
 
+    public void updateShieldBars(int playerShield, int enemyShield) {
+        if (userShieldLabel != null) {
+            userShieldLabel.setText(String.valueOf(playerShield));
+        }
+        if (enemyShieldLabel != null) {
+            enemyShieldLabel.setText(String.valueOf(enemyShield));
+        }
+    }
+
     public void updateTurnIndicator(String turnText) {
         if (turnIndicatorLabel != null) {
             turnIndicatorLabel.setText(turnText);
+        }
+    }
+
+    public void updateHpColors(boolean isPlayerPoisoned, boolean isEnemyPoisoned) {
+        if (userHpLabel != null) {
+            userHpLabel.setColor(isPlayerPoisoned ? Color.PURPLE : Color.WHITE);
+        }
+        if (enemyHpLabel != null) {
+            enemyHpLabel.setColor(isEnemyPoisoned ? Color.PURPLE : Color.WHITE);
+        }
+    }
+
+    public void updateShieldColors(boolean isPlayerShielded, boolean isEnemyShielded) {
+        if (userShieldLabel != null) {
+            userShieldLabel.setColor(isPlayerShielded ? Color.CYAN : Color.GRAY);
+        }
+        if (enemyShieldLabel != null) {
+            enemyShieldLabel.setColor(isEnemyShielded ? Color.CYAN : Color.GRAY);
         }
     }
 

--- a/core/src/main/java/com/altf4studios/corebringer/status/Poison.java
+++ b/core/src/main/java/com/altf4studios/corebringer/status/Poison.java
@@ -20,19 +20,19 @@ public class Poison extends StatusEffect {
      * @param target The entity to apply poison damage to
      */
     public void applyPoisonDamage(Entity target) {
-        if (target != null && target.isAlive() && duration > 0) {
-            // Apply poison damage (power amount)
+        if (target != null && target.isAlive() && power > 0) {
+            // Apply poison damage equal to current stacks (power)
             target.takeDamage(power);
             
             // Log the poison damage
             Gdx.app.log("Poison", target.getName() + " took " + power + " poison damage. Remaining HP: " + target.getHp());
             
-            // Reduce duration
-            duration--;
+            // Reduce stacks by 1 per turn
+            power--;
             
-            // Log remaining duration
-            if (duration > 0) {
-                Gdx.app.log("Poison", "Poison duration remaining: " + duration + " turns");
+            // Log remaining stacks
+            if (power > 0) {
+                Gdx.app.log("Poison", "Poison stacks remaining: " + power);
             } else {
                 Gdx.app.log("Poison", "Poison effect has expired");
             }
@@ -44,7 +44,7 @@ public class Poison extends StatusEffect {
      * @return true if duration is 0 or less
      */
     public boolean isExpired() {
-        return duration <= 0;
+        return power <= 0;
     }
 
     /**


### PR DESCRIPTION
Update Log:

- Now implemented Poison Status Effect. Player can now induce Poison Status effect to enemies. The Poison Status Effect stacks and will deal damage according to the stacks accumulated. One turn equals to One reduced stack.
- Now implemented Shielding. Player and Enemy can now gain Shielding. Player Cards can give Shielding while Enemy can randomly defend and gain Shielding at the cost of its turn. Shielding stacks and it will remain permanently. (buggy)
- Enemy AI is now smarter (slightly). Enemy can now attack and defend randomly, and the defense action of the enemy will cause it to gain Shielding, making it tougher to defeat.

Bugs and Flaws:
- Poison Status Effect could bug out and give a permanent amount of poison to enemy, making the fight too easy.
- Shielding could bug and may reach negative values on specific points when Player commences actions too quickly.

(Please do appropriate tests on the update and report bugs immediately. There may be some bugs or flaws I haven't found yet, both in and out of the game)